### PR TITLE
Add defaults

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,9 @@ info:
 ### value
 The `value` field can be used to change the default value of the info field. The value can be resolved (see [Resolvable fields](#resolvable-fields)).
 
+### defaults
+The `defaults` field can be used to define defaults for resolvable `INFO` and `FORMAT` fields. These defaults will be used when the required field is missing from the variant. 
+
 ### type
 The `type` field can be used to set the type of the info field (This will be reflected in the header of the output VCF file).
 
@@ -58,6 +61,8 @@ For example when all `SVLEN` info fields are positive, you maybe want to change 
 info:
   SVLEN:
     value: $INFO/SVLEN
+    defaults:
+      $INFO/SVLEN: "-1"
     type: Integer
     description: "Structural variant length"
     number: 1
@@ -71,6 +76,9 @@ The `format` section can be used to change the format fields for each variant. T
 format:
   <format_field>:
     value: <new_value>
+    defaults:
+      <resolvable-field>: <default>
+      <resolvable-field>: <default>
     type: <new_type>
     description: <new_description>
     number: <new_number>

--- a/svync.go
+++ b/svync.go
@@ -13,7 +13,7 @@ func main() {
 		Name:            "svync",
 		Usage:           "A tool to standardize VCF files from structural variant callers",
 		HideHelpCommand: true,
-		Version:         "0.1.2",
+		Version:         "0.2.0dev",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:     "nodate",

--- a/svync_api/config.go
+++ b/svync_api/config.go
@@ -79,7 +79,10 @@ func (config *Config) defineMissing() {
 	// Format fields
 	if _, ok := config.Format["GT"]; !ok {
 		config.Format["GT"] = ConfigInput{
-			Value:       "$FORMAT/GT",
+			Value: "$FORMAT/GT",
+			Defaults: map[string]string{
+				"$FORMAT/GT": "./.",
+			},
 			Number:      "1",
 			Type:        "String",
 			Description: "Genotype",

--- a/svync_api/execute.go
+++ b/svync_api/execute.go
@@ -20,10 +20,10 @@ func Execute(Cctx *cli.Context, config *Config) {
 
 	file := Cctx.String("input")
 	inputVcf, err := os.Open(file)
-	defer inputVcf.Close()
 	if err != nil {
 		logger.Fatal(err)
 	}
+	defer inputVcf.Close()
 	header := newHeader()
 	breakEndVariants := &map[string]Variant{}
 	headerIsMade := false

--- a/svync_api/standardize.go
+++ b/svync_api/standardize.go
@@ -102,7 +102,7 @@ func (variant *Variant) standardize(config *Config, Cctx *cli.Context, count int
 		}
 	}
 
-	standardizedVariant.Id = fmt.Sprintf("%s_%v", ResolveValue(config.Id, variant, nil, Cctx), count)
+	standardizedVariant.Id = fmt.Sprintf("%s_%v", ResolveValue(config.Id, variant, nil, Cctx, config), count)
 
 	// Add info fields
 	for name, infoConfig := range config.Info {
@@ -114,7 +114,7 @@ func (variant *Variant) standardize(config *Config, Cctx *cli.Context, count int
 		if value == "" {
 			continue
 		}
-		standardizedVariant.Info[name] = []string{ResolveValue(value, variant, nil, Cctx)}
+		standardizedVariant.Info[name] = []string{ResolveValue(value, variant, nil, Cctx, config)}
 	}
 
 	// Add format fields
@@ -127,7 +127,7 @@ func (variant *Variant) standardize(config *Config, Cctx *cli.Context, count int
 			if val, ok := formatConfig.Alts[sVType]; ok {
 				value = val
 			}
-			newFormat.Content[name] = []string{ResolveValue(value, variant, &format, Cctx)}
+			newFormat.Content[name] = []string{ResolveValue(value, variant, &format, Cctx, config)}
 		}
 		standardizedVariant.Format[sample] = *newFormat
 	}

--- a/svync_api/structs.go
+++ b/svync_api/structs.go
@@ -62,6 +62,7 @@ type Config struct {
 type MapConfigInput map[string]ConfigInput
 type ConfigInput struct {
 	Value       string
+	Defaults    map[string]string
 	Description string
 	Number      string
 	Type        string

--- a/svync_api/variant.go
+++ b/svync_api/variant.go
@@ -45,10 +45,10 @@ func toBreakPoint(mate1 *Variant, mate2 *Variant) *Variant {
 		filter = mate1.Filter
 	}
 
-	varQual, err := strconv.ParseFloat(mate1.Qual, 64)
-	mateQual, err := strconv.ParseFloat(mate2.Qual, 64)
+	varQual, err1 := strconv.ParseFloat(mate1.Qual, 64)
+	mateQual, err2 := strconv.ParseFloat(mate2.Qual, 64)
 	qual := "."
-	if err == nil {
+	if err1 == nil && err2 == nil {
 		qual = fmt.Sprintf("%f", (varQual+mateQual)/2)
 	}
 


### PR DESCRIPTION
This PR adds the `defaults` key for `info` and `format` configurations:
e.g.:
```yaml
info:
  SVLEN:
    value: $INFO/SVLEN
    defaults:
      $INFO/SVLEN: "-1"
    type: Integer
    description: "Structural variant length"
    number: 1
    alts:
      DEL: -$INFO/SVLEN
```